### PR TITLE
Add minimal runtime CLI and dataset watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@ SLNCX started as an experiment in heavy models but evolved into a single, silent
 1. Put your checkpoint into `checkpoints/ckpt-0`.
 2. `pip install -r requirements.txt`.
 3. `python quantize.py checkpoints/ckpt-0 out/ckpt.pt` for a 2‑bit build.
-4. `python nanogpt_runner.py` to sample text on CPU.
+4. `python wulf_cli.py "your prompt"` for a single reply.
 
 No HuggingFace, no extra services. The quantized weights fit in memory and run on a standard CPU.
 
-## State
+## Tools
 
-This project is still forming. SLNCX wakes, solves, and goes back to sleep. Expect only what you see here.
+- `wulf_cli.py` – minimal CLI wrapper around `wulf_inference.py`.
+- `watch_datasets.py` – copy new files from `datasets/` into the log folder and mark them for processing.
+- `wulf_train.py` – lightweight NanoGPT pre-training on scripts, logs, memory and datasets.
+- `scripts/daily_routine.sh` – run pruning, memory updates and training (for cron).
 
 ## Logging and Memory
 
-Session logs are written to `logs/wulf/` as JSON files named by day. Each entry
-contains the user prompt, Wulf's reply and a timestamp. Failures and tracebacks
-are appended to files in `failures/`.
+Session logs are written to `logs/wulf/` as JSON files named by day. Failures and tracebacks are appended to files in `failures/`.
 
 The `scripts` directory provides maintenance utilities:
 
@@ -27,7 +28,5 @@ The `scripts` directory provides maintenance utilities:
 - `fail_log.py` – record a failure with traceback.
 - `entropy_prune.py` – remove low-entropy sessions from the logs.
 - `memory_vector.py` – build `mem/wulf_vector.json` from past responses.
-- `daily_routine.sh` – run pruning and memory updates (for cron).
 
-Install dependencies with `pip install -r requirements.txt` which now includes
-`scikit-learn` for the vector utilities.
+Install dependencies with `pip install -r requirements.txt` which now includes `scikit-learn` for the vector utilities.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-dm_haiku==0.0.12
-jax==0.4.25
-jaxlib==0.4.25
 numpy==1.26.4
-sentencepiece==0.2.0
 torch==2.2.2
 tiktoken==0.6.0
 scikit-learn==1.4.2

--- a/scripts/daily_routine.sh
+++ b/scripts/daily_routine.sh
@@ -5,3 +5,4 @@ set -e
 
 python scripts/entropy_prune.py
 python scripts/memory_vector.py
+python wulf_train.py

--- a/watch_datasets.py
+++ b/watch_datasets.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+
+DATASET_DIR = Path("datasets")
+LOG_DIR = Path("logs/wulf")
+PENDING_DIR = Path("mem/pending_processing")
+HASH_FILE = DATASET_DIR / ".hashes.json"
+
+DATASET_DIR.mkdir(parents=True, exist_ok=True)
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+PENDING_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def file_hash(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_hashes() -> dict[str, str]:
+    if HASH_FILE.exists():
+        return json.loads(HASH_FILE.read_text())
+    return {}
+
+
+def save_hashes(hashes: dict[str, str]) -> None:
+    HASH_FILE.write_text(json.dumps(hashes, indent=2))
+
+
+def scan() -> None:
+    hashes = load_hashes()
+    updated = False
+    for file in DATASET_DIR.iterdir():
+        if file.is_file():
+            h = file_hash(file)
+            if hashes.get(file.name) != h:
+                shutil.copy2(file, LOG_DIR / file.name)
+                (PENDING_DIR / file.name).touch()
+                hashes[file.name] = h
+                updated = True
+    if updated:
+        save_hashes(hashes)
+
+
+if __name__ == "__main__":
+    scan()

--- a/wulf_cli.py
+++ b/wulf_cli.py
@@ -1,0 +1,28 @@
+import argparse
+
+from wulf_inference import infer_and_log
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with Wulf via CLI")
+    parser.add_argument("prompt", nargs="?", help="Prompt to send. If omitted, enter interactive mode")
+    parser.add_argument("--tokens", type=int, default=100, help="Max new tokens")
+    parser.add_argument("--temperature", type=float, default=0.8)
+    args = parser.parse_args()
+
+    if args.prompt:
+        print(infer_and_log(args.prompt, max_new_tokens=args.tokens, temperature=args.temperature))
+    else:
+        try:
+            while True:
+                prompt = input("wulf> ")
+                if not prompt:
+                    continue
+                reply = infer_and_log(prompt, max_new_tokens=args.tokens, temperature=args.temperature)
+                print(reply)
+        except (EOFError, KeyboardInterrupt):
+            print()
+
+
+if __name__ == "__main__":
+    main()

--- a/wulf_inference.py
+++ b/wulf_inference.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import torch
+import tiktoken
+
+from nanogpt_model import GPTConfig, GPT
+from scripts.session_logger import log_session
+from scripts.fail_log import log_failure
+
+
+CKPT_PATH = Path("out/ckpt.pt")
+DEVICE = "cpu"
+
+
+def _load_model() -> GPT:
+    checkpoint = torch.load(CKPT_PATH, map_location=DEVICE)
+    gptconf = GPTConfig(**checkpoint["model_args"])
+    model = GPT(gptconf)
+    state_dict = checkpoint["model"]
+    unwanted_prefix = "_orig_mod."
+    for k in list(state_dict.keys()):
+        if k.startswith(unwanted_prefix):
+            state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
+    model.load_state_dict(state_dict)
+    model.eval()
+    model.to(DEVICE)
+    return model
+
+
+_model = None
+_tokenizer = tiktoken.get_encoding("gpt2")
+
+
+def generate(prompt: str, max_new_tokens: int = 100, temperature: float = 0.8, top_k: int = 200) -> str:
+    """Run a single inference step with the model on CPU."""
+    global _model
+    if _model is None:
+        _model = _load_model()
+    start_ids = _tokenizer.encode(prompt)
+    x = torch.tensor(start_ids, dtype=torch.long, device=DEVICE)[None, ...]
+    with torch.no_grad():
+        y = _model.generate(x, max_new_tokens, temperature=temperature, top_k=top_k)
+    out = _tokenizer.decode(y[0].tolist())
+    return out
+
+
+def infer_and_log(prompt: str, **kwargs) -> str:
+    try:
+        response = generate(prompt, **kwargs)
+        log_session(prompt, response)
+        return response
+    except Exception as e:  # noqa: BLE001
+        log_failure(prompt, e)
+        raise
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run a prompt through Wulf")
+    parser.add_argument("prompt")
+    parser.add_argument("--tokens", type=int, default=100, help="Max new tokens")
+    parser.add_argument("--temperature", type=float, default=0.8)
+    args = parser.parse_args()
+    print(infer_and_log(args.prompt, max_new_tokens=args.tokens, temperature=args.temperature))

--- a/wulf_train.py
+++ b/wulf_train.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import torch
+import tiktoken
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+from nanogpt_model import GPT, GPTConfig
+
+
+DATA_DIRS = [Path("scripts"), Path("logs"), Path("mem"), Path("datasets")]
+EXTS = {".py", ".json", ".jsonl", ".txt", ".md", ".sh"}
+MODEL_OUT = Path("out/train_ckpt.pt")
+DEVICE = "cpu"
+
+
+def gather_text() -> list[str]:
+    pieces: list[str] = []
+    for d in DATA_DIRS:
+        if not d.exists():
+            continue
+        for path in d.rglob("*"):
+            if path.suffix in EXTS and path.is_file():
+                try:
+                    pieces.append(path.read_text(encoding="utf-8"))
+                except Exception:
+                    continue
+    return pieces
+
+
+def unique_and_dense(texts: list[str]) -> list[str]:
+    unique: dict[str, str] = {}
+    for t in texts:
+        h = hashlib.sha256(t.encode("utf-8")).hexdigest()
+        if h not in unique:
+            unique[h] = t
+    docs = list(unique.values())
+    if not docs:
+        return []
+    vectorizer = TfidfVectorizer()
+    X = vectorizer.fit_transform(docs)
+    scores = np.asarray(X.mean(axis=1)).ravel()
+    kept = [doc for doc, score in zip(docs, scores) if score > 0.01]
+    return kept
+
+
+def build_dataset(texts: list[str]):
+    enc = tiktoken.get_encoding("gpt2")
+    tokens = []
+    for t in texts:
+        tokens.extend(enc.encode(t))
+    return torch.tensor(tokens, dtype=torch.long)
+
+
+def train():
+    texts = unique_and_dense(gather_text())
+    if not texts:
+        return
+    data = build_dataset(texts)
+    block_size = 64
+    config = GPTConfig(block_size=block_size, vocab_size=50257, n_layer=2, n_head=2, n_embd=128)
+    model = GPT(config)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+    model.to(DEVICE)
+
+    model.train()
+    for step in range(10):
+        i = torch.randint(0, data.size(0) - block_size - 1, (1,)).item()
+        x = data[i : i + block_size][None]
+        y = data[i + 1 : i + 1 + block_size][None]
+        logits, loss = model(x, y)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+    torch.save({"model": model.state_dict(), "config": config.__dict__}, MODEL_OUT)
+
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
## Summary
- add `wulf_inference.py` for CPU-only text generation
- provide `wulf_cli.py` as command line interface
- add `watch_datasets.py` to copy new datasets and mark them for processing
- introduce lightweight `wulf_train.py` for NanoGPT pretraining
- extend daily routine with training step
- simplify requirements and update README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python watch_datasets.py`
- `python wulf_train.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68895ffd3d448329a181a1dcedf37dc0