### PR TITLE
Add Wulf runtime tools and self‑training

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ SLNCX started as an experiment in heavy models but evolved into a single, silent
 1. Put your checkpoint into `checkpoints/ckpt-0`.
 2. `pip install -r requirements.txt`.
 3. `python quantize.py checkpoints/ckpt-0 out/ckpt.pt` for a 2‑bit build.
-4. `python nanogpt_runner.py` to sample text on CPU.
+4. `python wulf_cli.py "your prompt"` to query Wulf.
+5. `python watch_datasets.py` to pull in new local datasets.
+6. `python wulf_train.py` for a lightweight self‑training pass.
 
 No HuggingFace, no extra services. The quantized weights fit in memory and run on a standard CPU.
 
@@ -24,10 +26,13 @@ are appended to files in `failures/`.
 The `scripts` directory provides maintenance utilities:
 
 - `session_logger.py` – append a prompt/response pair to the current log.
+- `wulf_cli.py` – simple CLI to query the model.
 - `fail_log.py` – record a failure with traceback.
 - `entropy_prune.py` – remove low-entropy sessions from the logs.
 - `memory_vector.py` – build `mem/wulf_vector.json` from past responses.
 - `daily_routine.sh` – run pruning and memory updates (for cron).
+- `watch_datasets.py` – copy new datasets into `logs/wulf/`.
+- `wulf_train.py` – perform a quick self‑training cycle.
 
 Install dependencies with `pip install -r requirements.txt` which now includes
 `scikit-learn` for the vector utilities.

--- a/scripts/daily_routine.sh
+++ b/scripts/daily_routine.sh
@@ -5,3 +5,5 @@ set -e
 
 python scripts/entropy_prune.py
 python scripts/memory_vector.py
+python watch_datasets.py
+python wulf_train.py

--- a/watch_datasets.py
+++ b/watch_datasets.py
@@ -1,0 +1,45 @@
+import json
+import hashlib
+import shutil
+from pathlib import Path
+from datetime import datetime
+
+DATA_DIR = Path('datasets')
+LOG_DIR = Path('logs/wulf')
+INDEX_FILE = LOG_DIR / 'dataset_index.json'
+
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def file_hash(path: Path) -> str:
+    return hashlib.md5(path.read_bytes()).hexdigest()
+
+
+def load_index() -> dict:
+    if INDEX_FILE.exists():
+        return json.loads(INDEX_FILE.read_text(encoding='utf-8'))
+    return {}
+
+
+def save_index(index: dict) -> None:
+    INDEX_FILE.write_text(json.dumps(index, ensure_ascii=False, indent=2), encoding='utf-8')
+
+
+def watch() -> None:
+    index = load_index()
+    updated = False
+    for file in DATA_DIR.iterdir():
+        if not file.is_file():
+            continue
+        h = file_hash(file)
+        if index.get(file.name) != h:
+            shutil.copy2(file, LOG_DIR / file.name)
+            (LOG_DIR / f'{file.stem}.pending').write_text(datetime.utcnow().isoformat(), encoding='utf-8')
+            index[file.name] = h
+            updated = True
+    if updated:
+        save_index(index)
+
+
+if __name__ == '__main__':
+    watch()

--- a/wulf_cli.py
+++ b/wulf_cli.py
@@ -1,0 +1,13 @@
+import argparse
+from wulf_inference import generate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Wulf1 CLI interface')
+    parser.add_argument('prompt', help='prompt text')
+    args = parser.parse_args()
+    print(generate(args.prompt))
+
+
+if __name__ == '__main__':
+    main()

--- a/wulf_inference.py
+++ b/wulf_inference.py
@@ -1,0 +1,51 @@
+import argparse
+from pathlib import Path
+
+import torch
+import tiktoken
+
+from nanogpt_model import GPTConfig, GPT
+from scripts.session_logger import log_session
+from scripts.fail_log import log_failure
+
+CKPT_PATH = Path('out/ckpt.pt')
+
+
+def load_model() -> GPT:
+    checkpoint = torch.load(CKPT_PATH, map_location='cpu')
+    gptconf = GPTConfig(**checkpoint['model_args'])
+    model = GPT(gptconf)
+    state_dict = checkpoint['model']
+    unwanted_prefix = '_orig_mod.'
+    for k in list(state_dict.keys()):
+        if k.startswith(unwanted_prefix):
+            state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
+    model.load_state_dict(state_dict)
+    model.eval()
+    return model
+
+
+def generate(prompt: str, max_new_tokens: int = 100) -> str:
+    model = load_model()
+    enc = tiktoken.get_encoding('gpt2')
+    idx = torch.tensor(enc.encode(prompt), dtype=torch.long)[None, ...]
+    with torch.no_grad():
+        y = model.generate(idx, max_new_tokens, temperature=0.8, top_k=200)
+    return enc.decode(y[0].tolist())
+
+
+def main(prompt: str) -> None:
+    try:
+        response = generate(prompt)
+        log_session(prompt, response)
+        print(response)
+    except Exception as e:
+        log_failure(prompt, e)
+        raise
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Run Wulf inference')
+    parser.add_argument('prompt', help='prompt text')
+    args = parser.parse_args()
+    main(args.prompt)

--- a/wulf_train.py
+++ b/wulf_train.py
@@ -1,0 +1,86 @@
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+import tiktoken
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+from nanogpt_model import GPT, GPTConfig
+
+DATA_DIRS = [Path('scripts'), Path('logs'), Path('mem'), Path('datasets')]
+TRAIN_CORPUS = Path('datasets/wulf_corpus.txt')
+MODEL_OUT = Path('out/wulf_pretrained.pt')
+
+
+def collect_texts() -> list[str]:
+    exts = {'.py', '.json', '.jsonl', '.txt', '.md', '.sh'}
+    texts = []
+    for d in DATA_DIRS:
+        if not d.exists():
+            continue
+        for path in d.rglob('*'):
+            if path.suffix.lower() in exts and path.is_file():
+                try:
+                    texts.append(path.read_text(encoding='utf-8'))
+                except Exception:
+                    continue
+    return texts
+
+
+def dedupe(texts: list[str]) -> list[str]:
+    seen = {}
+    for t in texts:
+        h = hashlib.sha1(t.encode('utf-8')).hexdigest()
+        if h not in seen:
+            seen[h] = t
+    return list(seen.values())
+
+
+def filter_dense(texts: list[str], threshold: float = 0.05) -> list[str]:
+    if not texts:
+        return []
+    vec = TfidfVectorizer().fit_transform(texts)
+    scores = np.asarray(vec.mean(axis=1)).ravel()
+    return [t for t, s in zip(texts, scores) if s > threshold]
+
+
+def build_corpus() -> str:
+    texts = collect_texts()
+    texts = dedupe(texts)
+    texts = filter_dense(texts)
+    corpus = '\n'.join(texts)
+    TRAIN_CORPUS.write_text(corpus, encoding='utf-8')
+    return corpus
+
+
+def simple_pretrain(text: str, steps: int = 50) -> None:
+    enc = tiktoken.get_encoding('gpt2')
+    tokens = torch.tensor(enc.encode(text), dtype=torch.long)
+    block_size = 64
+    cfg = GPTConfig(block_size=block_size, n_layer=2, n_head=2, n_embd=128)
+    model = GPT(cfg)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    model.train()
+    for _ in range(steps):
+        if len(tokens) <= block_size + 1:
+            break
+        i = torch.randint(0, len(tokens) - block_size - 1, (1,)).item()
+        x = tokens[i:i+block_size][None, ...]
+        y = tokens[i+1:i+block_size+1][None, ...]
+        logits, loss = model(x, y)
+        loss.backward()
+        opt.step()
+        opt.zero_grad()
+    torch.save({'model_args': cfg.__dict__, 'model': model.state_dict()}, MODEL_OUT)
+
+
+def main() -> None:
+    corpus = build_corpus()
+    if corpus:
+        simple_pretrain(corpus)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add dataset watcher to ingest files from `datasets/`
- implement `wulf_inference.py` and lightweight CLI
- create zero-to-loop `wulf_train.py`
- extend `daily_routine.sh` with watch and train steps
- update README with new commands

## Testing
- `python -m py_compile watch_datasets.py wulf_inference.py wulf_cli.py wulf_train.py`

------
https://chatgpt.com/codex/tasks/task_e_68895ffd3d448329a181a1dcedf37dc0