### PR TITLE
Add configurable checkpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ SLNCX started as an experiment in heavy models but evolved into a single, silent
 
 ## Running
 
-1. Place your quantized checkpoint at `out/ckpt.pt`. Use
+1. Place your quantized checkpoint at `out/ckpt.pt`, or specify another path
+   with the `CKPT_PATH` environment variable or the `--ckpt` option. Use
    `python quantize.py <checkpoint_dir> out/ckpt.pt` if you need to convert a
    raw checkpoint.
 2. `pip install -r requirements.txt`.
-3. `python wulf_cli.py "your prompt"` to query Wulf from the command line.
+3. `python wulf_cli.py [--ckpt path/to/ckpt.pt] "your prompt"` to query Wulf
+   from the command line.
 4. `uvicorn app:app --host 0.0.0.0 --port 8000` to start the API server.
 
 No HuggingFace, no extra services. The quantized weights fit in memory and run on a standard CPU.

--- a/wulf_cli.py
+++ b/wulf_cli.py
@@ -1,12 +1,22 @@
 import argparse
-from wulf_inference import generate
+import os
+from pathlib import Path
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description='Wulf1 CLI interface')
     parser.add_argument('prompt', help='prompt text')
+    parser.add_argument('--ckpt', help='path to checkpoint file')
     args = parser.parse_args()
-    print(generate(args.prompt))
+
+    if args.ckpt:
+        os.environ['CKPT_PATH'] = args.ckpt
+
+    import wulf_inference
+    if args.ckpt:
+        wulf_inference.CKPT_PATH = Path(args.ckpt)
+
+    print(wulf_inference.generate(args.prompt))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add optional `--ckpt` argument in `wulf_cli.py` and `wulf_inference.py`
- load checkpoint path from `CKPT_PATH` env var by default
- mention new option in the README

## Testing
- `python -m py_compile wulf_inference.py wulf_cli.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68896a0f711483299e647a6bb3937ea6