### PR TITLE
Switch session logs to JSONL format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ This project is still forming. SLNCX wakes, solves, and goes back to sleep. Expe
 
 ## Logging and Memory
 
-Session logs are written to `logs/wulf/` as JSON files named by day. Each entry
-contains the user prompt, Wulf's reply and a timestamp. Failures and tracebacks
-are appended to files in `failures/`.
+Session logs are written to `logs/wulf/` as JSONL files named by day. Each line
+is a JSON object with the user prompt, Wulf's reply and a timestamp. Failures
+and tracebacks are appended to files in `failures/`.
 
 The `scripts` directory contains simple helpers:
 
 - `session_logger.py` – append a prompt/response pair to the current log.
 - `wulf_cli.py` – minimal CLI for local prompts.
 - `fail_log.py` – record a failure with traceback.
+- `read_session_logs.py` – print entries from a log file.
 
 Install dependencies with `pip install -r requirements.txt` and start the
 server with `python app.py` or use the CLI for one-off queries.

--- a/scripts/read_session_logs.py
+++ b/scripts/read_session_logs.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+LOG_DIR = Path('logs/wulf')
+
+
+def read_logs(day: str | None = None):
+    """Yield log entries for the given day (default: today)."""
+    day = day or datetime.utcnow().strftime('%Y-%m-%d')
+    log_file = LOG_DIR / f"{day}.jsonl"
+    if not log_file.exists():
+        return
+    with log_file.open('r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Print session log entries")
+    parser.add_argument("--day", help="YYYY-MM-DD of the log to read")
+    args = parser.parse_args()
+    for entry in read_logs(args.day):
+        print(json.dumps(entry, ensure_ascii=False))

--- a/scripts/session_logger.py
+++ b/scripts/session_logger.py
@@ -11,7 +11,7 @@ LOG_DIR.mkdir(parents=True, exist_ok=True)
 def log_session(prompt: str, response: str, user: str | None = None) -> None:
     """Append a single session entry to today's log."""
     day = datetime.utcnow().strftime('%Y-%m-%d')
-    log_file = LOG_DIR / f"{day}.json"
+    log_file = LOG_DIR / f"{day}.jsonl"
     entry = {
         "timestamp": datetime.utcnow().isoformat(),
         "prompt": prompt,
@@ -19,17 +19,8 @@ def log_session(prompt: str, response: str, user: str | None = None) -> None:
     }
     if user:
         entry["user"] = user
-    data = []
-    if log_file.exists():
-        try:
-            data = json.loads(log_file.read_text(encoding='utf-8'))
-        except json.JSONDecodeError:
-            data = []
-    data.append(entry)
-    log_file.write_text(
-        json.dumps(data, ensure_ascii=False, indent=2),
-        encoding='utf-8',
-    )
+    with log_file.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- simplify `log_session` by writing JSONL lines
- add `read_session_logs.py` helper
- document new log format in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68896a05eb408329a1c7cbb33beb517c