### PR TITLE
Move tokenizer init

### DIFF
--- a/tests/test_wulf.py
+++ b/tests/test_wulf.py
@@ -1,5 +1,61 @@
-import torch
-import wulf_inference
+import sys
+
+
+class _Tensor:
+    def __init__(self, data):
+        self.data = data
+
+    def __getitem__(self, _):
+        return self
+
+    def tolist(self):
+        return self.data
+
+
+class _TorchStub:
+    long = int
+
+    @staticmethod
+    def tensor(data, dtype=None):
+        return _Tensor(data)
+
+    class no_grad:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+
+class _DummyEncodingStub:
+    def encode(self, text):
+        return [0]
+
+    def decode(self, ids):
+        return "dummy"
+
+
+class _TiktokenStub:
+    Encoding = object
+    @staticmethod
+    def get_encoding(name):
+        return _DummyEncodingStub()
+
+
+class _GPTStub:
+    class GPTConfig:
+        pass
+
+    class GPT:
+        pass
+
+
+sys.modules.setdefault("torch", _TorchStub())
+sys.modules.setdefault("tiktoken", _TiktokenStub())
+sys.modules.setdefault("nanogpt_model", _GPTStub)
+
+import torch  # noqa: E402
+import wulf_inference  # noqa: E402
 
 
 def test_generate(monkeypatch):
@@ -18,7 +74,7 @@ def test_generate(monkeypatch):
         return DummyModel()
 
     monkeypatch.setattr(wulf_inference, "load_model", dummy_load_model)
-    monkeypatch.setattr(wulf_inference.tiktoken, "get_encoding", lambda name: DummyEncoding())
+    monkeypatch.setattr(wulf_inference, "ENCODER", DummyEncoding())
 
     result = wulf_inference.generate("hi")
     assert result == "dummy"

--- a/wulf_inference.py
+++ b/wulf_inference.py
@@ -10,7 +10,8 @@ from scripts.session_logger import log_session
 from scripts.fail_log import log_failure
 
 MODEL: GPT | None = None
-ENCODER: tiktoken.Encoding | None = None
+# Initialize the encoder at import time so it is available immediately.
+ENCODER: tiktoken.Encoding = tiktoken.get_encoding("gpt2")
 
 # Default checkpoint location can be overridden via the CKPT_PATH
 # environment variable.
@@ -44,9 +45,6 @@ def load_model(ckpt_path: str | Path | None = None) -> GPT:
 def generate(prompt: str, max_new_tokens: int = 100) -> str:
     """Generate a response using the cached model."""
     model = load_model()
-    global ENCODER
-    if ENCODER is None:
-        ENCODER = tiktoken.get_encoding("gpt2")
     enc = ENCODER
     idx = torch.tensor(enc.encode(prompt), dtype=torch.long)[None, ...]
     with torch.no_grad():


### PR DESCRIPTION
## Summary
- preload tokenizer when importing `wulf_inference`
- adjust generate() to use the cached tokenizer
- update unit test with stubs so tests run without heavy deps

## Testing
- `ruff check wulf_inference.py tests/test_wulf.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897ca255fc83298c92c75fe0d03d4d